### PR TITLE
Fix cmake for OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ PROJECT (CLICKHOUSE-CLIENT)
     SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 
     IF (UNIX)
-        SET (CMAKE_CXX_FLAGS "-pthread -Wall -Wextra -Werror")
+        IF (APPLE)
+            SET (CMAKE_CXX_FLAGS "-Wall -Wextra -Werror")
+        ELSE ()
+            SET (CMAKE_CXX_FLAGS "-pthread -Wall -Wextra -Werror")
+        ENDIF ()
         SET (CMAKE_EXE_LINKER_FLAGS, "-lpthread")
     ENDIF ()
 


### PR DESCRIPTION
I was having a problem compiling this with the stock Apple's clang compiler.

Here's the log:
```
❯ cmake .
-- The C compiler identification is AppleClang 7.0.0.7000176
-- The CXX compiler identification is AppleClang 7.0.0.7000176
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/igor/Projects/clickhouse-cpp

❯ make
Scanning dependencies of target clickhouse-cpp-lib
[ 11%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/base/platform.cpp.o
[ 22%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/io/coded_input.cpp.o
[ 33%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/io/input.cpp.o
[ 44%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/io/output.cpp.o
[ 55%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/net/socket.cpp.o
[ 66%] Building CXX object clickhouse/CMakeFiles/clickhouse-cpp-lib.dir/client.cpp.o
[ 77%] Linking CXX static library libclickhouse-cpp-lib.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libclickhouse-cpp-lib.a(platform.cpp.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libclickhouse-cpp-lib.a(platform.cpp.o) has no symbols
[ 77%] Built target clickhouse-cpp-lib
Scanning dependencies of target simple-test
[ 88%] Building CXX object tests/simple/CMakeFiles/simple-test.dir/main.cpp.o
[100%] Linking CXX executable simple-test
clang: error: argument unused during compilation: '-pthread'
make[2]: *** [tests/simple/simple-test] Error 1
make[1]: *** [tests/simple/CMakeFiles/simple-test.dir/all] Error 2
make: *** [all] Error 2
```