### PR TITLE
Removed explicitly specified build type for library

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -1,4 +1,4 @@
-ADD_LIBRARY (clickhouse-cpp-lib STATIC
+ADD_LIBRARY (clickhouse-cpp-lib
     base/coded.cpp
     base/input.cpp
     base/output.cpp


### PR DESCRIPTION
Hello!

If you omit library type cmake will build STATIC library by default. But in addition it could build dynamic library if your user explicitly asked cmake to do it this way:
```
cmake -DBUILD_SHARED_LIBS:BOOL=ON ..
```