### PR TITLE
add method to retrieve nested type of Nullable type

### DIFF
--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -35,6 +35,13 @@ TypeRef Type::GetItemType() const {
     return TypeRef();
 }
 
+TypeRef Type::GetNestedType() const {
+    if (code_ == Nullable) {
+        return nullable_->nested_type;
+    }
+    return TypeRef();
+}
+
 std::string Type::GetName() const {
     switch (code_) {
         case Void:

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -40,6 +40,9 @@ public:
     /// Type of array's elements.
     TypeRef GetItemType() const;
 
+    /// Type of nested nullable element.
+    TypeRef GetNestedType() const;
+
     /// String representation of the type.
     std::string GetName() const;
 

--- a/ut/types_ut.cpp
+++ b/ut/types_ut.cpp
@@ -31,3 +31,11 @@ TEST(TypesCase, TypeName) {
         "Tuple(Int32, String)"
     );
 }
+
+TEST(TypesCase, NullableType) {
+    TypeRef nested = Type::CreateSimple<int32_t>();
+    ASSERT_EQ(
+        Type::CreateNullable(nested)->GetNestedType(),
+        nested
+    );
+}


### PR DESCRIPTION
Hi,

I added a method for retrieving the nested type of a `Nullable` type, as an equivalent to `GetItemType` for `Array`. (Of course, adding this functionality to `GetItemType` itself would work just as well. It's a matter of preference.)

Thanks!