### PR TITLE
Buck Builds

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,2 @@
+[cxx]
+  gtest_dep = //contrib/gtest:gtest

--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,10 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Buck
+/buck-out/
+/.buckd/
+/buckaroo/
+.buckconfig.local
+BUCKAROO_DEPS

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,20 @@
+cxx_library(
+  name = 'clickhouse-cpp',
+  header_namespace = 'clickhouse',
+  exported_headers = subdir_glob([
+    ('clickhouse', '**/*.h'),
+  ]),
+  srcs = glob([
+    'clickhouse/**/*.cpp',
+  ]),
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+  deps = [
+    '//contrib/cityhash:cityhash',
+    '//contrib/lz4:lz4',
+  ]
+)

--- a/contrib/cityhash/BUCK
+++ b/contrib/cityhash/BUCK
@@ -1,0 +1,13 @@
+cxx_library(
+  name = 'cityhash',
+  header_namespace = 'cityhash',
+  exported_headers = subdir_glob([
+    ('', '*.h'),
+  ]),
+  srcs = glob([
+    '*.cc',
+  ]),
+  visibility = [
+    '//...',
+  ],
+)

--- a/contrib/gtest/BUCK
+++ b/contrib/gtest/BUCK
@@ -1,0 +1,14 @@
+cxx_library(
+  name = 'gtest',
+  # This is a bit weird, but this is how the tests use the headers... 
+  header_namespace = 'contrib/gtest',
+  exported_headers = subdir_glob([
+    ('', '*.h'),
+  ]),
+  srcs = glob([
+    '*.cc',
+  ]),
+  visibility = [
+    '//...',
+  ],
+)

--- a/contrib/lz4/BUCK
+++ b/contrib/lz4/BUCK
@@ -1,0 +1,13 @@
+cxx_library(
+  name = 'lz4',
+  header_namespace = 'lz4',
+  exported_headers = subdir_glob([
+    ('', '*.h'),
+  ]),
+  srcs = glob([
+    '*.c',
+  ]),
+  visibility = [
+    '//...',
+  ],
+)

--- a/tests/simple/BUCK
+++ b/tests/simple/BUCK
@@ -1,0 +1,12 @@
+cxx_binary(
+  name = 'simple',
+  srcs = [
+    'main.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:clickhouse-cpp',
+  ],
+)

--- a/ut/BUCK
+++ b/ut/BUCK
@@ -1,0 +1,12 @@
+cxx_test(
+  name = 'ut',
+  srcs = glob([
+    '*.cpp',
+  ]),
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:clickhouse-cpp',
+  ],
+)


### PR DESCRIPTION
This PR adds [Buck](https://buckbuild.com/) build support to clickhouse-cpp. 

The library target is `//:clickhouse-cpp`, so to build: 

```
buck build :clickhouse-cpp
```

The tests have also been ported: 

```
buck test
```

The existing CMake build is unchanged; the two can coexist peacefully 😊