### PR TITLE
client insert reeceive fix typo throw exception

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -203,7 +203,7 @@ void Client::Impl::Insert(const std::string& table_name, const Block& block) {
         bool ret = ReceivePacket(&server_packet);
 
         if (!ret) {
-            std::runtime_error("fail to receive data packet");
+            throw std::runtime_error("fail to receive data packet");
         }
         if (server_packet == ServerCodes::Data) {
             break;


### PR DESCRIPTION
Found typo during client::insert(). Due to type exception doesn't throw and probably corrupting connection.