### PR TITLE
implement Slice for ColumnNullable

### DIFF
--- a/clickhouse/columns/nullable.cpp
+++ b/clickhouse/columns/nullable.cpp
@@ -54,9 +54,7 @@ size_t ColumnNullable::Size() const {
 }
 
 ColumnRef ColumnNullable::Slice(size_t begin, size_t len) {
-    (void)begin;
-    (void)len;
-    return ColumnRef();
+    return std::make_shared<ColumnNullable>(nested_->Slice(begin, len), nulls_->Slice(begin, len));
 }
 
 }


### PR DESCRIPTION
Among other things, this is required for retrieving entries from an `Array(Nullable(...))` column using `ColumnArray::GetAsColumn`.