### PR TITLE
add support for UUID column type

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -14,6 +14,7 @@ ADD_LIBRARY (clickhouse-cpp-lib
     columns/numeric.cpp
     columns/string.cpp
     columns/tuple.cpp
+    columns/uuid.cpp
 
     types/type_parser.cpp
     types/types.cpp

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -10,6 +10,7 @@
 #include "columns/numeric.h"
 #include "columns/string.h"
 #include "columns/tuple.h"
+#include "columns/uuid.h"
 
 #include <chrono>
 #include <memory>

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -7,6 +7,7 @@
 #include "numeric.h"
 #include "string.h"
 #include "tuple.h"
+#include "uuid.h"
 
 #include "../types/type_parser.h"
 
@@ -31,6 +32,9 @@ static ColumnRef CreateTerminalColumn(const TypeAst& ast) {
         return std::make_shared<ColumnInt32>();
     if (ast.name == "Int64")
         return std::make_shared<ColumnInt64>();
+
+    if (ast.name == "UUID")
+        return std::make_shared<ColumnUUID>();
 
     if (ast.name == "Float32")
         return std::make_shared<ColumnFloat32>();

--- a/clickhouse/columns/uuid.cpp
+++ b/clickhouse/columns/uuid.cpp
@@ -1,0 +1,57 @@
+#include "uuid.h"
+#include "utils.h"
+
+namespace clickhouse {
+
+ColumnUUID::ColumnUUID()
+    : Column(Type::CreateUUID())
+    , data_(std::make_shared<ColumnUInt64>())
+{
+}
+
+ColumnUUID::ColumnUUID(ColumnRef data)
+    : Column(Type::CreateUUID())
+    , data_(data->As<ColumnUInt64>())
+{
+    if (data_->Size()%2 != 0) {
+        throw std::runtime_error("number of entries must be even (two 64-bit numbers for each UUID)");
+    }
+}
+
+void ColumnUUID::Append(const UInt128& value) {
+    data_->Append(value.first);
+    data_->Append(value.second);
+}
+
+const UInt128 ColumnUUID::At(size_t n) const {
+    return UInt128(data_->At(n * 2), data_->At(n * 2 + 1));
+}
+
+const UInt128 ColumnUUID::operator [] (size_t n) const {
+    return UInt128((*data_)[n * 2], (*data_)[n * 2 + 1]);
+}
+
+void ColumnUUID::Append(ColumnRef column) {
+    if (auto col = column->As<ColumnUUID>()) {
+        data_->Append(data_);
+    }
+}
+
+bool ColumnUUID::Load(CodedInputStream* input, size_t rows) {
+    return data_->Load(input, rows * 2);
+}
+
+void ColumnUUID::Save(CodedOutputStream* output) {
+    data_->Save(output);
+}
+
+size_t ColumnUUID::Size() const {
+    return data_->Size() / 2;
+}
+
+ColumnRef ColumnUUID::Slice(size_t begin, size_t len) {
+    return std::make_shared<ColumnUUID>(data_->Slice(begin * 2, len * 2));
+}
+
+}
+

--- a/clickhouse/columns/uuid.h
+++ b/clickhouse/columns/uuid.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "column.h"
+#include "numeric.h"
+
+namespace clickhouse {
+
+using UInt128 = std::pair<uint64_t, uint64_t>;
+
+/**
+ * Represents a UUID column.
+ */
+class ColumnUUID : public Column {
+public:
+    ColumnUUID();
+
+    explicit ColumnUUID(ColumnRef data);
+
+    /// Appends one element to the end of column.
+    void Append(const UInt128& value);
+
+    /// Returns element at given row number.
+    const UInt128 At(size_t n) const;
+
+    /// Returns element at given row number.
+    const UInt128 operator [] (size_t n) const;
+
+public:
+    /// Appends content of given column to the end of current one.
+    void Append(ColumnRef column) override;
+
+    /// Loads column data from input stream.
+    bool Load(CodedInputStream* input, size_t rows) override;
+
+    /// Saves column data to output stream.
+    void Save(CodedOutputStream* output) override;
+
+    /// Returns count of rows in the column.
+    size_t Size() const override;
+
+    /// Makes slice of the current column.
+    ColumnRef Slice(size_t begin, size_t len) override;
+
+private:
+    std::shared_ptr<ColumnUInt64> data_;
+};
+
+}

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -68,6 +68,8 @@ std::string Type::GetName() const {
             return "UInt32";
         case UInt64:
             return "UInt64";
+        case UUID:
+            return "UUID";
         case Float32:
             return "Float32";
         case Float64:
@@ -180,6 +182,10 @@ TypeRef Type::CreateEnum16(const std::vector<EnumItem>& enum_items) {
         type->enum_->name_to_value[item.name] = item.value;
     }
     return type;
+}
+
+TypeRef Type::CreateUUID() {
+    return TypeRef(new Type(Type::UUID));
 }
 
 

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -32,6 +32,7 @@ public:
         Tuple,
         Enum8,
         Enum16,
+        UUID,
     };
 
     struct EnumItem {
@@ -78,6 +79,8 @@ public:
     static TypeRef CreateEnum8(const std::vector<EnumItem>& enum_items);
 
     static TypeRef CreateEnum16(const std::vector<EnumItem>& enum_items);
+
+    static TypeRef CreateUUID();
 
 private:
     Type(const Code code);

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -4,6 +4,7 @@
 #include <clickhouse/columns/nullable.h>
 #include <clickhouse/columns/numeric.h>
 #include <clickhouse/columns/string.h>
+#include <clickhouse/columns/uuid.h>
 
 #include <contrib/gtest/gtest.h>
 
@@ -27,6 +28,13 @@ static std::vector<std::string> MakeFixedStrings() {
 static std::vector<std::string> MakeStrings() {
     return std::vector<std::string>
         {"a", "ab", "abc", "abcd"};
+}
+
+static std::vector<uint64_t> MakeUUIDs() {
+    return std::vector<uint64_t>
+        {0xbb6a8c699ab2414cllu, 0x86697b7fd27f0825llu,
+         0x84b9f24bc26b49c6llu, 0xa03b4ab723341951llu,
+         0x3507213c178649f9llu, 0x9faf035d662f60aellu};
 }
 
 
@@ -135,4 +143,21 @@ TEST(ColumnsCase, NullableSlice) {
     ASSERT_TRUE(sub->IsNull(1));
     ASSERT_FALSE(sub->IsNull(3));
     ASSERT_EQ(subData->At(3), 17u);
+}
+
+TEST(ColumnsCase, UUIDInit) {
+    auto col = std::make_shared<ColumnUUID>(std::make_shared<ColumnUInt64>(MakeUUIDs()));
+
+    ASSERT_EQ(col->Size(), 3u);
+    ASSERT_EQ(col->At(0), UInt128(0xbb6a8c699ab2414cllu, 0x86697b7fd27f0825llu));
+    ASSERT_EQ(col->At(2), UInt128(0x3507213c178649f9llu, 0x9faf035d662f60aellu));
+}
+
+TEST(ColumnsCase, UUIDSlice) {
+    auto col = std::make_shared<ColumnUUID>(std::make_shared<ColumnUInt64>(MakeUUIDs()));
+    auto sub = col->Slice(1, 2)->As<ColumnUUID>();
+
+    ASSERT_EQ(sub->Size(), 2u);
+    ASSERT_EQ(sub->At(0), UInt128(0x84b9f24bc26b49c6llu, 0xa03b4ab723341951llu));
+    ASSERT_EQ(sub->At(1), UInt128(0x3507213c178649f9llu, 0x9faf035d662f60aellu));
 }


### PR DESCRIPTION
Hi,

here's a patch for supporting UUID columns.

Of course, this could also be implemented more concisely as `ColumnVector<UInt128>`, assuming you rely on the layout and packing of `std::pair` (or a custom struct), which would probably be reasonable given that it consists of two `uint64_t`.

This patch, on the other hand, doesn't make any assumptions of that sort.