### PR TITLE
Added Select signature

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -455,6 +455,7 @@ bool Client::Impl::ReceiveData() {
 
     if (events_) {
         events_->OnData(block);
+        events_->OnDataWithInfo(block);
         if (!events_->OnDataCancelable(block)) {
             SendCancel();
         }
@@ -721,6 +722,11 @@ void Client::Execute(const Query& query) {
 void Client::Select(const std::string& query, SelectCallback cb) {
     Execute(Query(query).OnData(cb));
 }
+
+void Client::Select(const std::string& query, void* extraInfo, SelectCallbackWithInfo cb) {
+    Execute(Query(query).OnDataWithInfo(cb, extraInfo));
+}
+
 
 void Client::SelectCancelable(const std::string& query, SelectCancelableCallback cb) {
     Execute(Query(query).OnDataCancelable(cb));

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -80,6 +80,11 @@ public:
     /// one or more call of \p cb.
     void Select(const std::string& query, SelectCallback cb);
 
+    /// Intends for execute select queries.  Data will be returned with
+    /// one or more call of \p cb.
+    /// extraInfo will be passed to callback
+    void Select(const std::string& query, void* extraInfo, SelectCallbackWithInfo cb);
+
     /// Executes a select query which can be canceled by returning false from
     /// the data handler function \p cb.
     void SelectCancelable(const std::string& query, SelectCancelableCallback cb);


### PR DESCRIPTION
Added possibility to add a void* extra Info to the Select function, it will be returned in the select callback.
Useful for example when one wants to add a pointer to the object, handling the select result.