### PR TITLE
Enumerated all fields explicitly for INSERT operation

### DIFF
--- a/contrib/cityhash/CMakeLists.txt
+++ b/contrib/cityhash/CMakeLists.txt
@@ -1,3 +1,5 @@
 ADD_LIBRARY (cityhash-lib STATIC
     city.cc
 )
+
+set_property(TARGET cityhash-lib PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/contrib/lz4/CMakeLists.txt
+++ b/contrib/lz4/CMakeLists.txt
@@ -2,3 +2,5 @@ ADD_LIBRARY (lz4-lib STATIC
     lz4.c
     lz4hc.c
 )
+
+set_property(TARGET lz4-lib PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Hello!

After Clickhouse release 18.12.14 I noticed Clickhouse server crashes and reported them to Yandex: https://github.com/yandex/ClickHouse/issues/3141

Alexey Milovidov found issue and it was caused by different number of fields in table and number of fields in insert operation.

But that's my case because as suggested in https://github.com/artpaul/clickhouse-cpp/issues/38 I switched to "DEFAULT" value for single field and do not populate it from INSERT operation.

In this PR I added explicit enumeration for all fields to avoid such issue. After this fix, issue disappeared and Clickhouse serveк (18.12.17) did not crash anymore.

And insert operation looks like:
```
2018.09.20 23:08:36.266265 [ 24 ] {27fc3e44-cdc8-4585-a705-021b448eb4d4} <Debug> executeQuery: (from 127.0.0.1:53863) INSERT INTO meta.host_metrics ( metricDateTime,host,packets_incoming,packets_outgoing,bits_incoming,bits_outgoing,flows_incoming,flows_outgoing  ) VALUES
```

Thank you!