### PR TITLE
Fixes typo in ColumnUUID::Append(ColumnUUID)

### DIFF
--- a/clickhouse/columns/uuid.cpp
+++ b/clickhouse/columns/uuid.cpp
@@ -37,7 +37,7 @@ const UInt128 ColumnUUID::operator [] (size_t n) const {
 
 void ColumnUUID::Append(ColumnRef column) {
     if (auto col = column->As<ColumnUUID>()) {
-        data_->Append(data_);
+        data_->Append(col->data_);
     }
 }
 


### PR DESCRIPTION
The Append method overload for concatenating two ColumnUUID's did not actually append anything.
This patch fixes it.