### PR TITLE
Added Nulls getter to manipulate internal nulls on ColumnNullable

### DIFF
--- a/clickhouse/columns/nullable.cpp
+++ b/clickhouse/columns/nullable.cpp
@@ -23,6 +23,10 @@ ColumnRef ColumnNullable::Nested() const {
     return nested_;
 }
 
+ColumnRef ColumnNullable::Nulls() const {
+    return nulls_;
+}
+
 void ColumnNullable::Append(ColumnRef column) {
     if (auto col = column->As<ColumnNullable>()) {
         if (!col->nested_->Type()->IsEqual(nested_->Type())) {

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -18,6 +18,9 @@ public:
     /// Returns nested column.
     ColumnRef Nested() const;
 
+    /// Returns nulls column.
+    ColumnRef Nulls() const;
+
 public:
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;


### PR DESCRIPTION
Hello,

This commit will allow the programmer to access the nulls_ column.
In my use case, I need to access the nulls too. This is a similar approach:
```c++
auto col = columns[0]->As<ColumnNullable>();
col->Nested()->As<ColumnString>()->Append(this->value);
col->Nulls()->As<ColumnUInt8>()->Append(!this->is_value_ok());
```

Thanks.