### PR TITLE
Add read/write timeouts to connection socket

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -125,14 +125,9 @@ const struct addrinfo* NetworkAddress::Info() const {
 }
 
 
-SocketTimeoutParams::SocketTimeoutParams(
-        unsigned int connection_socket_recv_timeout_sec,
-        unsigned int connection_socket_recv_timeout_usec,
-        unsigned int connection_socket_send_timeout_sec,
-        unsigned int connection_socket_send_timeout_usec
-) :
-    recv_timeout_{.tv_sec = connection_socket_recv_timeout_sec, .tv_usec = connection_socket_recv_timeout_usec},
-    send_timeout_{.tv_sec = connection_socket_send_timeout_sec, .tv_usec = connection_socket_send_timeout_usec}
+SocketTimeoutParams::SocketTimeoutParams( unsigned int con_recv_timeout_sec, unsigned int con_send_timeout_sec)
+    : recv_timeout_{.tv_sec = con_recv_timeout_sec, .tv_usec = 0},
+      send_timeout_{.tv_sec = con_send_timeout_sec, .tv_usec = 0}
 {
 }
 

--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -72,6 +72,18 @@ void SetNonBlock(SOCKET fd, bool value) {
 #endif
 }
 
+void SetTimeout(SOCKET fd, SocketTimeoutParams params) {
+#if defined(_unix_)
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &params.GetRecvTimeout(), sizeof(params.GetRecvTimeout())) < 0) {
+        throw std::system_error(errno, std::system_category(), "failed to setsockopt(SO_RCVTIMEO)");
+    }
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &params.GetSendTimeout(), sizeof(params.GetSendTimeout())) < 0) {
+        throw std::system_error(errno, std::system_category(), "failed to setsockopt(SO_SNDTIMEO)");
+    }
+#endif
+}
+
 } // namespace
 
 NetworkAddress::NetworkAddress(const std::string& host, const std::string& port)
@@ -110,6 +122,26 @@ NetworkAddress::~NetworkAddress() {
 
 const struct addrinfo* NetworkAddress::Info() const {
     return info_;
+}
+
+
+SocketTimeoutParams::SocketTimeoutParams(
+        unsigned int connection_socket_recv_timeout_sec,
+        unsigned int connection_socket_recv_timeout_usec,
+        unsigned int connection_socket_send_timeout_sec,
+        unsigned int connection_socket_send_timeout_usec
+) :
+    recv_timeout_{.tv_sec = connection_socket_recv_timeout_sec, .tv_usec = connection_socket_recv_timeout_usec},
+    send_timeout_{.tv_sec = connection_socket_send_timeout_sec, .tv_usec = connection_socket_send_timeout_usec}
+{
+}
+
+const struct timeval& SocketTimeoutParams::GetRecvTimeout(){
+    return recv_timeout_;
+}
+
+const struct timeval& SocketTimeoutParams::GetSendTimeout(){
+    return send_timeout_;
 }
 
 
@@ -253,7 +285,7 @@ NetworkInitializer::NetworkInitializer() {
 }
 
 
-SOCKET SocketConnect(const NetworkAddress& addr) {
+SOCKET SocketConnect(const NetworkAddress& addr, const std::optional<SocketTimeoutParams>& socket_timeout_params) {
     int last_err = 0;
     for (auto res = addr.Info(); res != nullptr; res = res->ai_next) {
         SOCKET s(socket(res->ai_family, res->ai_socktype, res->ai_protocol));
@@ -263,6 +295,9 @@ SOCKET SocketConnect(const NetworkAddress& addr) {
         }
 
         SetNonBlock(s, true);
+        if(socket_timeout_params) {
+            SetTimeout(s, *socket_timeout_params);
+        }
 
         if (connect(s, res->ai_addr, (int)res->ai_addrlen) != 0) {
             int err = errno;

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <string>
+#include <optional>
 
 #if defined(_win_)
 #   pragma comment(lib, "Ws2_32.lib")
@@ -24,6 +25,7 @@
 #endif
 
 struct addrinfo;
+struct timeval;
 
 namespace clickhouse {
 
@@ -40,6 +42,23 @@ public:
 
 private:
     struct addrinfo* info_;
+};
+
+class SocketTimeoutParams {
+public:
+    explicit SocketTimeoutParams(
+        unsigned int connection_socket_recv_timeout_sec,
+        unsigned int connection_socket_recv_timeout_usec,
+        unsigned int connection_socket_send_timeout_sec,
+        unsigned int connection_socket_send_timeout_usec
+    );
+
+    const struct timeval& GetRecvTimeout();
+    const struct timeval& GetSendTimeout();
+
+private:
+    const struct timeval recv_timeout_;
+    const struct timeval send_timeout_;
 };
 
 
@@ -106,7 +125,7 @@ static struct NetworkInitializer {
 } gNetworkInitializer;
 
 ///
-SOCKET SocketConnect(const NetworkAddress& addr);
+SOCKET SocketConnect(const NetworkAddress& addr, const std::optional<SocketTimeoutParams>& socket_timeout_params);
 
 ssize_t Poll(struct pollfd* fds, int nfds, int timeout) noexcept;
 

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -46,12 +46,7 @@ private:
 
 class SocketTimeoutParams {
 public:
-    explicit SocketTimeoutParams(
-        unsigned int connection_socket_recv_timeout_sec,
-        unsigned int connection_socket_recv_timeout_usec,
-        unsigned int connection_socket_send_timeout_sec,
-        unsigned int connection_socket_send_timeout_usec
-    );
+    explicit SocketTimeoutParams(unsigned int con_recv_timeout_sec, unsigned int con_send_timeout_sec);
 
     const struct timeval& GetRecvTimeout();
     const struct timeval& GetSendTimeout();

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -167,11 +167,9 @@ Client::Impl::Impl(const ClientOptions& opts)
     , buffered_output_(&socket_output_)
     , output_(&buffered_output_)
 {
-    if (options_.connection_socket_timeout) {
+    if (options_.connection_timeout) {
         socket_timeout_params_.emplace(
-                options_.connection_socket_recv_timeout_sec, options_.connection_socket_recv_timeout_usec,
-                options_.connection_socket_send_timeout_sec, options_.connection_socket_send_timeout_usec
-        );
+                options_.connection_recv_timeout.count(), options_.connection_send_timeout.count());
     }
 
     for (unsigned int i = 0; ; ) {

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -141,6 +141,7 @@ private:
     QueryEvents* events_;
     int compression_ = CompressionState::Disable;
 
+    std::optional<SocketTimeoutParams> socket_timeout_params_;
     SocketHolder socket_;
 
     SocketInput socket_input_;
@@ -166,6 +167,13 @@ Client::Impl::Impl(const ClientOptions& opts)
     , buffered_output_(&socket_output_)
     , output_(&buffered_output_)
 {
+    if (options_.connection_socket_timeout) {
+        socket_timeout_params_.emplace(
+                options_.connection_socket_recv_timeout_sec, options_.connection_socket_recv_timeout_usec,
+                options_.connection_socket_send_timeout_sec, options_.connection_socket_send_timeout_usec
+        );
+    }
+
     for (unsigned int i = 0; ; ) {
         try {
             ResetConnection();
@@ -267,7 +275,8 @@ void Client::Impl::Ping() {
 }
 
 void Client::Impl::ResetConnection() {
-    SocketHolder s(SocketConnect(NetworkAddress(options_.host, std::to_string(options_.port))));
+    SocketHolder s(SocketConnect(
+            NetworkAddress(options_.host, std::to_string(options_.port)), socket_timeout_params_));
 
     if (s.Closed()) {
         throw std::system_error(errno, std::system_category());

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -69,6 +69,13 @@ struct ClientOptions {
     DECLARE_FIELD(tcp_keepalive_intvl, std::chrono::seconds, SetTcpKeepAliveInterval, std::chrono::seconds(5));
     DECLARE_FIELD(tcp_keepalive_cnt, unsigned int, SetTcpKeepAliveCount, 3);
 
+    /// Socket timeout
+    DECLARE_FIELD(connection_socket_timeout, bool, ConnectionTimeout, false);
+    DECLARE_FIELD(connection_socket_recv_timeout_sec, unsigned int, SetConnectionRecvTimeoutSeconds, 60);
+    DECLARE_FIELD(connection_socket_recv_timeout_usec, unsigned int, SetConnectionRecvTimeoutMicroseconds, 0);
+    DECLARE_FIELD(connection_socket_send_timeout_sec, unsigned int, SetConnectionSendTimeoutSeconds, 60);
+    DECLARE_FIELD(connection_socket_send_timeout_usec, unsigned int, SetConnectionSendTimeoutMicroseconds, 0);
+
 #undef DECLARE_FIELD
 };
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -69,12 +69,10 @@ struct ClientOptions {
     DECLARE_FIELD(tcp_keepalive_intvl, std::chrono::seconds, SetTcpKeepAliveInterval, std::chrono::seconds(5));
     DECLARE_FIELD(tcp_keepalive_cnt, unsigned int, SetTcpKeepAliveCount, 3);
 
-    /// Socket timeout
-    DECLARE_FIELD(connection_socket_timeout, bool, ConnectionTimeout, false);
-    DECLARE_FIELD(connection_socket_recv_timeout_sec, unsigned int, SetConnectionRecvTimeoutSeconds, 60);
-    DECLARE_FIELD(connection_socket_recv_timeout_usec, unsigned int, SetConnectionRecvTimeoutMicroseconds, 0);
-    DECLARE_FIELD(connection_socket_send_timeout_sec, unsigned int, SetConnectionSendTimeoutSeconds, 60);
-    DECLARE_FIELD(connection_socket_send_timeout_usec, unsigned int, SetConnectionSendTimeoutMicroseconds, 0);
+    /// Connection socket timeout
+    DECLARE_FIELD(connection_timeout, bool, ConnectionTimeout, false);
+    DECLARE_FIELD(connection_recv_timeout, std::chrono::seconds, SetConnectionRecvTimeout, std::chrono::seconds(60));
+    DECLARE_FIELD(connection_send_timeout, std::chrono::seconds, SetConnectionSendTimeout, std::chrono::seconds(60));
 
 #undef DECLARE_FIELD
 };


### PR DESCRIPTION
When working with the library, the following behavior was found:
when connecting to the clickhouse server,  the application may stick forever, due to connection problems.

A connection to the server can be established, but nothing can be read from the socket.

You can repeat this behaviour if you pass the value of another running application as the port. Then the connect stage successfully passes, but  we forever hang on reading from the socket in the DoRead function.

Is it possible to add the ability to set timeouts per socket to the library?
and is it worth making the default value of the timeout?